### PR TITLE
Add `mergeIterables()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,15 @@ for await (const item of mappedIterator) {
 
 ## API
 
-### `bufferedAsyncMap(input, callback[, { bufferSize=6 }]) => AsyncIterableIterator`
+### bufferedAsyncMap()
 
 Iterates and applies the `callback` to up to `bufferSize` items from `input` yielding values as they resolve.
+
+#### Syntax
+
+`bufferedAsyncMap(input, callback[, { bufferSize=6, ordered=false }]) => AsyncIterableIterator`
+
+#### Arguments
 
 * `input` – either an async iterable, an ordinare iterable or an array
 * `callback(item)` – should be either an async generator or an ordinary async function. Items from async generators are buffered in the main buffer and the buffer is refilled by the one that has least items in the current buffer (`input` is considered equal to sub iterators in this regard when refilling the buffer)
@@ -80,6 +86,22 @@ Iterates and applies the `callback` to up to `bufferSize` items from `input` yie
 
 * `bufferSize` – _optional_ – defaults to `6`, sets the max amount of simultanoeus items that processed at once in the buffer.
 * `ordered` – _optional_ – defaults to `false`, when `true` the result will be returned in order instead of unordered
+
+### mergeIterables()
+
+Merges all given (async) iterables in parallel, returning the values as they resolve
+
+#### Syntax
+
+`mergeIterables(input[, { bufferSize=6 }]) => AsyncIterableIterator`
+
+#### Arguments
+
+* `input` – either an async iterable, an ordinare iterable or an array
+
+#### Options
+
+* `bufferSize` – _optional_ – defaults to `6`, sets the max amount of simultanoeus items that processed at once in the buffer.
 
 ## Similar modules
 

--- a/index.js
+++ b/index.js
@@ -5,11 +5,29 @@
 // TODO: Look into https://tc39.es/ecma262/#sec-iteratorclose / https://tc39.es/ecma262/#sec-asynciteratorclose
 // TODO: See "iteratorKind" in https://tc39.es/ecma262/#sec-runtime-semantics-forin-div-ofbodyevaluation-lhs-stmt-iterator-lhskind-labelset – see how it loops and validates the returned values
 // TODO: THERE'S ACTUALLY A "throw" method MENTION IN https://tc39.es/ecma262/#sec-generator-function-definitions-runtime-semantics-evaluation: "NOTE: Exceptions from the inner iterator throw method are propagated. Normal completions from an inner throw method are processed similarly to an inner next." THOUGH NOT SURE HOW TO TRIGGER IT IN PRACTICE, SEE yield.spec.js
-// TODO: Make a proper merge for async iterables by accepting multiple input iterables, see: https://twitter.com/matteocollina/status/1392056092482576385
 
 import { findLeastTargeted } from './lib/find-least-targeted.js';
 import { arrayDeleteInPlace, makeIterableAsync } from './lib/misc.js';
 import { isAsyncIterable, isIterable, isPartOfArray } from './lib/type-checks.js';
+
+/**
+ * @template T
+ * @param {AsyncIterable<T> | Iterable<T> | T[]} item
+ * @returns {AsyncIterable<T>}
+ */
+async function * yieldIterable (item) {
+  yield * item;
+}
+
+/**
+ * @template T
+ * @param {Array<AsyncIterable<T> | Iterable<T> | T[]>} input
+ * @param {{ bufferSize?: number|undefined }} [options]
+ * @returns {AsyncIterable<T>}
+ */
+export async function * mergeIterables (input, { bufferSize } = {}) {
+  yield * bufferedAsyncMap(input, yieldIterable, { bufferSize });
+}
 
 /**
  * @template T


### PR DESCRIPTION
Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New mergeIterables() function enables concurrent processing of multiple iterables with configurable buffer size.
  * Enhanced bufferedAsyncMap with optional "ordered" parameter to control result ordering behavior.

* **Documentation**
  * Updated API documentation for new mergeIterables function and bufferedAsyncMap enhancements.

* **Tests**
  * Expanded test coverage for mergeIterables functionality and parallel processing validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->