### PR TITLE
fix: build type declarations on install so git-dep consumers get types

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "check:type-coverage": "type-coverage --detail --strict --at-least 95 --ignore-files 'test/*.spec.js'",
     "clean": "run-p clean:*",
     "clean:declarations": "rm -rf $(find . -maxdepth 2 -type f -name '*.d.ts*')",
-    "prepare": "husky",
+    "prepare": "husky && run-s build",
     "prepublishOnly": "run-s build",
     "test": "run-s check test:*",
     "test:mocha": "c8 --reporter=lcov --reporter text mocha 'test/**/*.spec.js'",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "check:type-coverage": "type-coverage --detail --strict --at-least 95 --ignore-files 'test/*.spec.js'",
     "clean": "run-p clean:*",
     "clean:declarations": "rm -rf $(find . -maxdepth 2 -type f -name '*.d.ts*')",
-    "prepare": "husky && run-s build",
+    "prepare": "husky && run-s build:1-declaration",
     "prepublishOnly": "run-s build",
     "test": "run-s check test:*",
     "test:mocha": "c8 --reporter=lcov --reporter text mocha 'test/**/*.spec.js'",


### PR DESCRIPTION
## Problem

The declaration build (`tsc -p declaration.tsconfig.json`) only runs on `prepublishOnly`, which npm fires **solely on `npm publish`**. When the package is installed as a **git dependency**, [pacote](https://github.com/npm/pacote/blob/main/lib/dir.js) runs only the `prepare` script — previously just `husky` — so no `.d.ts` is ever emitted.

Meanwhile `package.json` declares `"types": "index.d.ts"` and lists `index.d.ts` / `index.d.ts.map` in `files`, and npm **silently omits** `files` entries that don't exist on disk. The result: anyone installing a branch to review it (e.g. `npm install github:voxpelli/buffered-async-iterable#<branch>`) gets a package that advertises types and ships none.

```console
$ npm install 'github:voxpelli/buffered-async-iterable#<branch>'
$ ls node_modules/buffered-async-iterable/
ADVANCED.md  index.js  lib  LICENSE  package.json  README.md   # no index.d.ts
$ node -p "require('buffered-async-iterable/package.json').types"
index.d.ts                                                     # but it claims one
```

## Fix

Run the declaration build from `prepare` too:

```diff
-    "prepare": "husky",
+    "prepare": "husky && run-s build",
```

Why `prepare` and not `prepack`:

- `prepare` **composes** — husky still installs its hooks, then the build runs.
- `prepare` existing is *why* devDependencies (`typescript`, `run-s`) get installed for a git dep at all; npm installs a git dep's devDependencies only when a `prepare` script is present.
- `prepare` fires on the git-install path that `prepublishOnly`/`prepack` never reach.

`prepublishOnly` is left in place; a second build on `npm publish` is harmless. Emitted `.d.ts` files stay gitignored, so nothing new is committed, and a fresh `npm install` now also builds them locally (a minor, expected cost).

## Verification

`npm run build` — the exact chain `prepare` now runs — emits `index.d.ts` + `index.d.ts.map`; both remain gitignored. Confirmed the `prepare` script executes the declaration build during a plain `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSyTJjbP823pjYfueuSsdu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSyTJjbP823pjYfueuSsdu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- **Fix:** Run `build:1-declaration` during `prepare` after Husky setup.
- This generates TypeScript declarations when installing from a Git dependency.
- Keep `prepublishOnly` unchanged.
- Avoid the full clean step to preserve Windows compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->